### PR TITLE
Add properties support for getSuggestions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
 		"prefer-destructuring": 0,
 		"no-console": ["error", { "allow": ["warn", "error"] }],
 		"class-methods-use-this": 0,
+		"no-prototype-builtins": 0,
 
 		"react/jsx-indent": [2, "tab"],
 		"react/jsx-indent-props": [2, "tab"],

--- a/src/utils/suggestions.js
+++ b/src/utils/suggestions.js
@@ -19,18 +19,35 @@ const extractSuggestion = (val) => {
 	}
 };
 
-const getSuggestions = (fields, suggestions, currentValue) => {
+const getSuggestions = (fields, suggestions, currentValue, suggestionProperties = []) => {
 	let suggestionsList = [];
 	let labelsList = [];
 
-	const populateSuggestionsList = (val) => {
+	const populateSuggestionsList = (val, source) => {
 		// check if the suggestion includes the current value
 		// and not already included in other suggestions
 		const isWordMatch = currentValue.trim().split(' ').some(term => val.includes(term));
 		if (isWordMatch && !labelsList.includes(val)) {
-			const option = {
+			const defaultOption = {
 				label: val,
 				value: val,
+			};
+
+			let additionalKeys = {};
+			if (Array.isArray(suggestionProperties) && suggestionProperties.length > 0) {
+				suggestionProperties.forEach((prop) => {
+					if (source.hasOwnProperty(prop)) {
+						additionalKeys = {
+							...additionalKeys,
+							[prop]: source[prop],
+						};
+					}
+				});
+			}
+
+			const option = {
+				...defaultOption,
+				...additionalKeys,
 			};
 			labelsList = [...labelsList, val];
 			suggestionsList = [...suggestionsList, option];
@@ -54,9 +71,9 @@ const getSuggestions = (fields, suggestions, currentValue) => {
 					const val = extractSuggestion(label);
 					if (val) {
 						if (Array.isArray(val)) {
-							val.forEach(suggestion => populateSuggestionsList(suggestion));
+							val.forEach(suggestion => populateSuggestionsList(suggestion, source));
 						} else {
-							populateSuggestionsList(val);
+							populateSuggestionsList(val, source);
 						}
 					}
 				}


### PR DESCRIPTION
Currently, we pass only `value` and `label` for suggestion objects internally.

With this support we can add properties that we want the suggestions object to contain like
```
getSuggestions(
  fields,
  results,
  value,
  [this.props.dataField, "some_property name"]
)
```