### PR TITLE
added index to the hit result in parseHits() in helper.js

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -252,6 +252,7 @@ export const parseHits = (hits) => {
 			const data = highlightResults(item);
 			return {
 				_id: data._id,
+				_index: data._index,
 				...data._source,
 				...streamProps,
 			};


### PR DESCRIPTION
Sorry if I am creating a pull request on the wrong repo. I am new to using submodules with GitHub. 

Reasoning:

If a user wants to search multiple indices at once by declaring their app name to be: "index0,index1,index2,index3,index4", and each of these indexes has a different structure, parsing the results can be a bit cumbersome.  If the result knows which index its hit came from the user can use a case statement to display different attributes for each type of result.

```
switch data._index
    case "index0":
        // code goes here
    case "index1":
    case "index2":
...
```