### PR TITLE
I have two commits and both or either can be used. In one method, I add to the result object the entire original hit. In the other, I only add on the original highlight item

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -253,6 +253,7 @@ export const parseHits = (hits) => {
 			return {
 				_id: data._id,
 				_index: data._index,
+				_original_result: item,
 				...data._source,
 				...streamProps,
 			};

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -227,14 +227,19 @@ export const handleA11yAction = (e, callback) => {
 };
 
 const highlightResults = (result) => {
-	const data = { ...result };
-	if (data.highlight) {
-		Object.keys(data.highlight).forEach((highlightItem) => {
-			const highlightValue = data.highlight[highlightItem][0];
-			data._source = Object.assign({}, data._source, { [highlightItem]: highlightValue });
-		});
-	}
-	return data;
+    const data = { ...result };
+    if (data.highlight) {
+        Object.keys(data.highlight).forEach((highlightItem) => {
+            const highlightValue = data.highlight[highlightItem][0];
+            const original = data._source[highlightItem];
+            const originalName = '_original_' + highlightItem;
+            data._source = Object.assign({}, data._source,
+                { [highlightItem]: highlightValue,
+                  [originalName]: original
+                });
+        });
+    }
+    return data;
 };
 
 export const parseHits = (hits) => {


### PR DESCRIPTION
My first method of adding on the entire original (first commit) does add a little bloat to the returned results. It simply adds the entire original result to the parsed result object.

I also implemented something that would return just the highlight field(s) in their original fashion (second commit).  This is more space efficient.

What do you think?  

In the screenshot, you can see both of these methods being returned in the data in the console. (_original_result, _original_name) (name being the modified highlight attribute.)

![screen shot 2018-05-29 at 11 35 00 am](https://user-images.githubusercontent.com/25523383/40669190-5f911870-6334-11e8-9bd3-db8ff60b7221.png)


