### PR TITLE
Fix SSR compatibility caused in v8.1.1

### DIFF
--- a/src/utils/polyfills.js
+++ b/src/utils/polyfills.js
@@ -62,5 +62,8 @@ if (typeof Event !== 'function') {
 		return evt;
 	}
 
+	if (typeof window === 'undefined') {
+		return;
+	}
 	window.Event = Event;
 }


### PR DESCRIPTION
This should fix the SSR compatibility in the library introduced in https://github.com/appbaseio/reactivecore/pull/35 (I am currently getting `window is not defined` when running my app)

I found the problem in the Vue library but I suppose this problem should exist in the React version too.