### PR TITLE
fix: data field validation for rs-api

### DIFF
--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -68,7 +68,7 @@ export const hasPaginationSupport = (componentType = '') =>
 	listComponentsWithPagination.includes(componentType);
 
 export const getRSQuery = (componentId, props, execute = true) => {
-	if (props && componentId && props.dataField) {
+	if (props && componentId) {
 		return {
 			id: componentId,
 			type: props.type ? props.type : componentToTypeMap[props.componentType],

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -30,6 +30,19 @@ function validateLocation(props, propName) {
 	return null;
 }
 
+// eslint-disable-next-line consistent-return
+const dataFieldValidator = (props, propName, componentName) => {
+	const requiredError = new Error(`${propName} supplied to ${componentName} is required. Validation failed.`);
+	const propValue = props[propName];
+	if (props.config && !props.config.enableAppbase) {
+		if (!propValue) return requiredError;
+		if (typeof propValue !== 'string' && !Array.isArray(propValue)) {
+			return new Error(`Invalid ${propName} supplied to ${componentName}. Validation failed.`);
+		}
+		if (Array.isArray(propValue && propValue.length === 0)) return requiredError;
+	}
+};
+
 const types = {
 	any,
 	analyticsConfig: shape({
@@ -160,6 +173,7 @@ const types = {
 	aggregationData: array,
 	showClearAll: oneOf([CLEAR_ALL.NEVER, CLEAR_ALL.ALWAYS, CLEAR_ALL.DEFAULT, true, false]),
 	componentObject: object,
+	dataFieldValidator,
 };
 
 export default types;

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -39,7 +39,7 @@ const dataFieldValidator = (props, propName, componentName) => {
 		if (typeof propValue !== 'string' && !Array.isArray(propValue)) {
 			return new Error(`Invalid ${propName} supplied to ${componentName}. Validation failed.`);
 		}
-		if (Array.isArray(propValue && propValue.length === 0)) return requiredError;
+		if (Array.isArray(propValue) && propValue.length === 0) return requiredError;
 	}
 };
 


### PR DESCRIPTION
## What this PR does?
- allows empty dataField when enableAppbase=true and checks through custom validator

## Test
https://www.loom.com/share/d5b6f21635434f43b112edcef5924202