### PR TITLE
fix: get predictive suggestions logic updated

### DIFF
--- a/src/utils/suggestions.js
+++ b/src/utils/suggestions.js
@@ -71,7 +71,7 @@ const getPredictiveSuggestions = ({
 
 			if (regexExecution) {
 				const matchedString = parsedContent.slice(regexExecution.index, parsedContent.length);
-				const suggestionPhrase = `<em>${currentValueTrimmed}</em><mark class="highlight predictive-suggestions">${matchedString
+				const suggestionPhrase = `${currentValueTrimmed}<mark class="highlight">${matchedString
 					.slice(currentValueTrimmed.length)
 					.split(' ')
 					.slice(0, wordsToShowAfterHighlight + 1)
@@ -234,21 +234,7 @@ const getSuggestions = ({
 			currentValue,
 			wordsToShowAfterHighlight,
 		});
-
-		const finalSuggestions = [];
-
-		const predictiveValues = predictiveSuggestions.reduce((arr, suggestion) => {
-			finalSuggestions.push(suggestion);
-			arr.push(suggestion.value);
-			return arr;
-		}, []);
-
-		suggestionsList.forEach((suggestion) => {
-			if (!predictiveValues.includes(suggestion.value)) {
-				finalSuggestions.push(suggestion);
-			}
-		});
-		suggestionsList = finalSuggestions;
+		suggestionsList = predictiveSuggestions;
 	}
 	return suggestionsList;
 };

--- a/src/utils/suggestions.js
+++ b/src/utils/suggestions.js
@@ -71,7 +71,7 @@ const getPredictiveSuggestions = ({
 
 			if (regexExecution) {
 				const matchedString = parsedContent.slice(regexExecution.index, parsedContent.length);
-				const suggestionPhrase = `${currentValueTrimmed}<mark class="highlight">${matchedString
+				const suggestionPhrase = `<em>${currentValueTrimmed}</em><mark class="highlight predictive-suggestions">${matchedString
 					.slice(currentValueTrimmed.length)
 					.split(' ')
 					.slice(0, wordsToShowAfterHighlight + 1)
@@ -234,7 +234,21 @@ const getSuggestions = ({
 			currentValue,
 			wordsToShowAfterHighlight,
 		});
-		suggestionsList = predictiveSuggestions;
+
+		const finalSuggestions = [];
+
+		const predictiveValues = predictiveSuggestions.reduce((arr, suggestion) => {
+			finalSuggestions.push(suggestion);
+			arr.push(suggestion.value);
+			return arr;
+		}, []);
+
+		suggestionsList.forEach((suggestion) => {
+			if (!predictiveValues.includes(suggestion.value)) {
+				finalSuggestions.push(suggestion);
+			}
+		});
+		suggestionsList = finalSuggestions;
 	}
 	return suggestionsList;
 };

--- a/src/utils/suggestions.js
+++ b/src/utils/suggestions.js
@@ -47,6 +47,7 @@ const getPredictiveSuggestions = ({
 }) => {
 	const suggestionMap = {};
 	if (currentValue) {
+		const currentValueTrimmed = currentValue.trim();
 		const parsedSuggestion = suggestions.reduce((agg, { label, ...rest }) => {
 			// to handle special strings with pattern '<mark>xyz</mark> <a href="test'
 			const parsedContent = new DOMParser().parseFromString(
@@ -56,22 +57,22 @@ const getPredictiveSuggestions = ({
 
 			// to match the partial start of word.
 			// example if searchTerm is `select` and string contains `selected`
-			let regexString = `(${currentValue})\\w+`;
+			let regexString = `^(${currentValueTrimmed})\\w+`;
 			let regex = new RegExp(regexString, 'i');
 			let regexExecution = regex.exec(parsedContent);
 			// if execution value is null it means either there is no match or there are chances
 			// that exact word is present
 			if (!regexExecution) {
 				// regex to match exact word
-				regexString = `(${currentValue})`;
+				regexString = `^(${currentValueTrimmed})`;
 				regex = new RegExp(regexString, 'i');
 				regexExecution = regex.exec(parsedContent);
 			}
 
 			if (regexExecution) {
 				const matchedString = parsedContent.slice(regexExecution.index, parsedContent.length);
-				const suggestionPhrase = `${currentValue}<mark class="highlight">${matchedString
-					.slice(currentValue.length)
+				const suggestionPhrase = `${currentValueTrimmed}<mark class="highlight">${matchedString
+					.slice(currentValueTrimmed.length)
 					.split(' ')
 					.slice(0, wordsToShowAfterHighlight + 1)
 					.join(' ')}</mark>`;
@@ -233,10 +234,7 @@ const getSuggestions = ({
 			currentValue,
 			wordsToShowAfterHighlight,
 		});
-
-		if (predictiveSuggestions.length) {
-			suggestionsList = predictiveSuggestions;
-		}
+		suggestionsList = predictiveSuggestions;
 	}
 	return suggestionsList;
 };


### PR DESCRIPTION
- Issue Type - Bug

- Description - There were some issues with getPredictiveSuggestions logic

1. The search value was not trimmed, therefore it was considering starting and trailing whitespaces if any to be a part of the search string
2. Prefixes were removed from some results to get the matched strings instead of matching them from the start
3. In getSuggestions when enablepredictiveSuggestions was set to true if the predictiveSuggestions list was empty, it was not returning an empty list

Demo-

https://www.loom.com/share/e56ab5f4a4f0417ab786acbf81a3e1fc