### PR TITLE
feat: support added for distinctfield prop

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -43,6 +43,8 @@ export const validProps = [
 	'componentType',
 	'aggregationField',
 	'aggregationSize',
+	'distinctField',
+	'distinctFieldConfig',
 	// Specific to ReactiveList
 	'dataField',
 	'includeFields',

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -114,6 +114,8 @@ export const getRSQuery = (componentId, props, execute = true) => {
 			selectAllLabel: props.selectAllLabel,
 			pagination: props.pagination,
 			queryString: props.queryString,
+			distinctField: props.distinctField,
+			distinctFieldConfig: props.distinctFieldConfig,
 		};
 	}
 	return null;


### PR DESCRIPTION
Support added for `distinctField` & `distinctFieldConfig` props in ReactiveSearch web and vue components - which returns distinct results based on a specified field.

For further reference please look into this PR - https://github.com/appbaseio/reactivesearch/pull/1654