### PR TITLE
fix: clear filter incase defaultvalue not provided

### DIFF
--- a/src/actions/value.js
+++ b/src/actions/value.js
@@ -40,11 +40,12 @@ export function resetValuesToDefault() {
 
 		let valueToSet;
 		Object.keys(selectedValues).forEach((component) => {
-			if (!componentProps[component] || !componentProps[component].componentType) {
+			if (
+				!componentProps[component]
+				|| !componentProps[component].componentType
+				|| !componentProps[component].defaultValue
+			) {
 				return true;
-			}
-			if (!componentProps[component].defaultValue) {
-				valueToSet = null;
 			} else if (
 				[
 					componentTypes.rangeSlider,
@@ -53,7 +54,7 @@ export function resetValuesToDefault() {
 				].includes(componentProps[component].componentType)
 			) {
 				valueToSet
-						= typeof componentProps[component].defaultValue === 'object'
+					= typeof componentProps[component].defaultValue === 'object'
 						? [
 							componentProps[component].defaultValue.start,
 							componentProps[component].defaultValue.end,

--- a/src/actions/value.js
+++ b/src/actions/value.js
@@ -40,14 +40,12 @@ export function resetValuesToDefault() {
 
 		let valueToSet;
 		Object.keys(selectedValues).forEach((component) => {
-			if (
-				!componentProps[component]
-				|| !componentProps[component].defaultValue
-				|| !componentProps[component].componentType
-			) {
+			if (!componentProps[component] || !componentProps[component].componentType) {
 				return true;
 			}
-			if (
+			if (!componentProps[component].defaultValue) {
+				valueToSet = null;
+			} else if (
 				[
 					componentTypes.rangeSlider,
 					componentTypes.ratingsFilter,
@@ -55,7 +53,7 @@ export function resetValuesToDefault() {
 				].includes(componentProps[component].componentType)
 			) {
 				valueToSet
-					= typeof componentProps[component].defaultValue === 'object'
+						= typeof componentProps[component].defaultValue === 'object'
 						? [
 							componentProps[component].defaultValue.start,
 							componentProps[component].defaultValue.end,

--- a/src/actions/value.js
+++ b/src/actions/value.js
@@ -45,7 +45,7 @@ export function resetValuesToDefault() {
 				|| !componentProps[component].componentType
 				|| !componentProps[component].defaultValue
 			) {
-				return true;
+				valueToSet = null;
 			} else if (
 				[
 					componentTypes.rangeSlider,

--- a/src/actions/value.js
+++ b/src/actions/value.js
@@ -49,6 +49,7 @@ export function resetValuesToDefault() {
 			} else if (
 				[
 					componentTypes.rangeSlider,
+					componentTypes.rangeInput,
 					componentTypes.ratingsFilter,
 					componentTypes.dateRange,
 				].includes(componentProps[component].componentType)

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -50,7 +50,7 @@ const types = {
 		emptyQuery: bool,
 		suggestionAnalytics: bool,
 		userId: string,
-		customEvents: object,
+		customEvents: object, // eslint-disable-line
 	}),
 	appbaseConfig: shape({
 		enableQueryRules: bool,
@@ -59,7 +59,7 @@ const types = {
 		emptyQuery: bool,
 		suggestionAnalytics: bool,
 		userId: string,
-		customEvents: object,
+		customEvents: object, // eslint-disable-line
 	}),
 	bool,
 	boolRequired: bool.isRequired,


### PR DESCRIPTION
Followup of #104 

Added fix for setting null value if `defaultValue` is not passed instead of returning from the method call.