### PR TITLE
feat: added type support for mongodb prop

### DIFF
--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -181,6 +181,10 @@ const types = {
 	componentObject: object,
 	dataFieldValidator,
 	focusShortcuts: oneOfType([arrayOf(string), arrayOf(number)]),
+	mongodb: shape({
+		db: string,
+		collection: string,
+	}),
 };
 
 export default types;


### PR DESCRIPTION
**PR Type**: `Feature`

**Description**
The PR integrates support for `mongodb` by adding a `type` for `mongodb` prop used by dependent libraries.

[📔 Notion](https://www.notion.so/appbase/Reactivesearch-Mongo-DB-Support-1ef6e865b5cf4204aaae338d22afa288)

**Related PR(s)** 
- https://github.com/appbaseio/reactivesearch/pull/1810
- https://github.com/appbaseio/appbase-js/pull/84