### PR TITLE
Feat/support date type for range components

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -100,6 +100,7 @@ export const validProps = [
 	'range',
 	'showSlider',
 	'parseDate',
+	'calendarInterval',
 	// Map components
 	'unit',
 ];

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -701,11 +701,16 @@ export const getTopSuggestions = (querySuggestions, currentValue = '', showDisti
 	return withClickIds(finalSuggestions);
 };
 
+/* isValidDateRangeQueryFormat() checks if the queryFormat is one of the dateFormats
+	accepted by the elasticsearch or not. */
 export function isValidDateRangeQueryFormat(queryFormat) {
 	return Object.keys(dateFormats).includes(queryFormat);
 }
 
 // converts a date type, if used, to a comparable numeric format
+/* getNumericRangeValue() function is used to retrieve a numeric value that can be compared
+ using comparison operators, when dealing with dates it is highly probable that we
+ would be getting date objects and sometimes date-strings that can't be compared directly */
 export function getNumericRangeValue(value, props, avoidEpochSecondDivision = false) {
 	// eslint-disable-next-line
 	if (
@@ -722,9 +727,9 @@ export function getNumericRangeValue(value, props, avoidEpochSecondDivision = fa
 	return parseFloat(value);
 }
 
-// converts a value type to a representational string format
-// based on the queryFormat if passed
-// else returns as is.
+/* getRangeValueString() returns a string from a date-(object, string, numeric) in
+	the queryFormat passed by the user. All for representational purpose, this value is the one
+	getting stored in reduc to be used by the selectedFilters, query-generation, urlparams, etc. */
 export function getRangeValueString(value, props) {
 	if (typeof value !== 'string') {
 		switch (props.queryFormat) {
@@ -751,8 +756,16 @@ export function getRangeValueString(value, props) {
 	return value;
 }
 
-// converts a string to a standard format which can be
-// parsed by the XDate constructor
+/* formatDateStringToStandard() returns a date-string that is acceptable by the XDate().
+	For Xdate() to prase date-strings, Date-strings must either be in ISO8601 format
+	or IETF format (like "Mon Sep 05 2011 12:30:00 GMT-0700 (PDT)")
+	Ref: https://arshaw.com/xdate/#Parsing
+
+	We need it when we are getting value from the Redux store, since we are storing values in
+	redux store that get used by the SelectedFilters and URLParams also,
+	these values are in the format passed by the user through queryFormat prop,
+	for example, a date string would be stored as HHmmss.fffzzz
+	when queryFormat === 'basic_time' but this can't be parsed by the Xdate constructor. */
 export function formatDateStringToStandard(value, props) {
 	const queryFormat = dateFormats[props.queryFormat];
 	let formattedValue = value;
@@ -821,3 +834,4 @@ export function formatDateStringToStandard(value, props) {
 	}
 	return formattedValue;
 }
+

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,7 +1,7 @@
 import XDate from 'xdate';
 import { componentTypes, queryTypes } from './constants';
 import dateFormats from './dateFormats';
-import { formatDate } from './helper';
+import { formatDate, isValidDateRangeQueryFormat } from './helper';
 
 export const componentToTypeMap = {
 	// search components
@@ -223,20 +223,11 @@ export const extractPropsFromState = (store, component, customOptions) => {
 
 			// Set value
 			if (value) {
-				if (componentProps.queryFormat) { // check if date types are dealt with
+				if (isValidDateRangeQueryFormat(componentProps.queryFormat)) {
+					// check if date types are dealt with
 					value = {
-						start:
-							// formatDate should be passed with a XDate parsable value
-							new XDate(value.start).valid()
-							// avoid passing value for epoch_second to avoid re division of value by 1000
-							&& componentProps.queryFormat !== dateFormats.epoch_second
-								? formatDate(new XDate(value.start), componentProps)
-								: value.start, // no formatting required
-						end:
-							new XDate(value.end).valid()
-							&& componentProps.queryFormat !== dateFormats.epoch_second
-								? formatDate(new XDate(value.end), componentProps)
-								: value.end,
+						start: formatDate(new XDate(value.start), componentProps),
+						end: formatDate(new XDate(value.end), componentProps),
 					};
 				} else {
 					value = {

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -212,7 +212,6 @@ export const extractPropsFromState = (store, component, customOptions) => {
 			aggregations = ['histogram'];
 		}
 
-
 		// handle number box, number box query changes based on the `queryFormat` value
 		if (
 			componentProps.componentType === componentTypes.dynamicRangeSlider
@@ -224,22 +223,27 @@ export const extractPropsFromState = (store, component, customOptions) => {
 
 			// Set value
 			if (value) {
-				/* eslint-disable */
-				value = {
-					start: componentProps.queryFormat
-						? new XDate(value.start).valid() &&
-						  componentProps.queryFormat !== dateFormats.epoch_second
-							? formatDate(new XDate(value.start), componentProps)
-							: value.start
-						: parseFloat(value.start),
-					end: componentProps.queryFormat
-						? new XDate(value.end).valid() &&
-						  componentProps.queryFormat !== dateFormats.epoch_second
-							? formatDate(new XDate(value.end), componentProps)
-							: value.end
-						: parseFloat(value.end),
-				};
-				/* eslint-enable */
+				if (componentProps.queryFormat) { // check if date types are dealt with
+					value = {
+						start:
+							// formatDate should be passed with a XDate parsable value
+							new XDate(value.start).valid()
+							// avoid passing value for epoch_second to avoid re division of value by 1000
+							&& componentProps.queryFormat !== dateFormats.epoch_second
+								? formatDate(new XDate(value.start), componentProps)
+								: value.start, // no formatting required
+						end:
+							new XDate(value.end).valid()
+							&& componentProps.queryFormat !== dateFormats.epoch_second
+								? formatDate(new XDate(value.end), componentProps)
+								: value.end,
+					};
+				} else {
+					value = {
+						start: parseFloat(value.start),
+						end: parseFloat(value.end),
+					};
+				}
 			}
 		}
 

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -153,7 +153,6 @@ export const extractPropsFromState = (store, component, customOptions) => {
 	let aggregations;
 	let pagination; // pagination for `term` type of queries
 	let from = componentProps.from; // offset for RL
-
 	// For term queries i.e list component `dataField` will be treated as aggregationField
 	if (queryType === queryTypes.term) {
 		// Only apply pagination prop for the components which supports it otherwise it can break the UI
@@ -213,6 +212,7 @@ export const extractPropsFromState = (store, component, customOptions) => {
 			aggregations = ['histogram'];
 		}
 
+
 		// handle number box, number box query changes based on the `queryFormat` value
 		if (
 			componentProps.componentType === componentTypes.dynamicRangeSlider
@@ -221,6 +221,7 @@ export const extractPropsFromState = (store, component, customOptions) => {
 			calendarInterval = Object.keys(dateFormats).includes(queryFormat)
 				? componentProps.calendarInterval || 'month'
 				: undefined;
+
 			// Set value
 			if (value) {
 				/* eslint-disable */
@@ -228,17 +229,13 @@ export const extractPropsFromState = (store, component, customOptions) => {
 					start: componentProps.queryFormat
 						? new XDate(value.start).valid() &&
 						  componentProps.queryFormat !== dateFormats.epoch_second
-							? componentProps.showHistogram
-								? new XDate(value.start).getTime()
-								: formatDate(new XDate(value.start), componentProps)
+							? formatDate(new XDate(value.start), componentProps)
 							: value.start
 						: parseFloat(value.start),
 					end: componentProps.queryFormat
 						? new XDate(value.end).valid() &&
 						  componentProps.queryFormat !== dateFormats.epoch_second
-							? componentProps.showHistogram
-								? new XDate(value.end).getTime()
-								: formatDate(new XDate(value.end), componentProps)
+							? formatDate(new XDate(value.end), componentProps)
 							: value.end
 						: parseFloat(value.end),
 				};

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -221,8 +221,6 @@ export const extractPropsFromState = (store, component, customOptions) => {
 			calendarInterval = Object.keys(dateFormats).includes(queryFormat)
 				? componentProps.calendarInterval || 'month'
 				: undefined;
-			// Remove
-			queryFormat = 'or';
 			// Set value
 			if (value) {
 				/* eslint-disable */

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -95,8 +95,8 @@ const types = {
 	options: oneOfType([arrayOf(object), object]),
 	paginationAt: oneOf(['top', 'bottom', 'both']),
 	range: shape({
-		start: number.isRequired,
-		end: number.isRequired,
+		start: oneOfType([number, object]).isRequired,
+		end: oneOfType([number, object]).isRequired,
 	}),
 	rangeLabels: shape({
 		start: string.isRequired,
@@ -185,6 +185,7 @@ const types = {
 		db: string,
 		collection: string,
 	}),
+	calendarInterval: oneOf(['month', 'day', 'year', 'week', 'quarter', 'hour', 'minute']),
 };
 
 export default types;


### PR DESCRIPTION
**PR Type** `Feature`

**Description** Adds support for rendering of date fields (year spans or month spans) with RangeSlider and DynamicRangeSlider.

[📔  Notion](https://www.notion.so/appbase/Support-date-type-for-Range-components-76194617cb334bb89d65c57c5e825b91)

[🎥  Loom Updated 22-12-2021](https://www.loom.com/share/da29c18ec2474a9daa7a01ab15e5ca03)

[🎥   CodeWalktrhough](https://www.loom.com/share/9f2dfb560a084bdb97b05917cc2c9b3e)

[🎥  Loom Updated 20-12-2021](https://www.loom.com/share/03d2477e7c7842c2bd2d4a7c0f22b2cc)
[🎥  Loom](https://www.loom.com/share/da19f82501004502b73bcb0bb9ce3230)

**Related PR(s) 👇**   
- https://github.com/appbaseio/playground/pull/71
- https://github.com/appbaseio/reactivesearch/pull/1825


--- 
> For testing locally, switch over to `feat/support-date-type-for-range-components` in all the three repos:
> `reactivesearch`, `reactivecore` & `playground`
> and run the storybook.
