### PR TITLE
refactor: added suggestionTypes constants to reactive core lib

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -705,3 +705,10 @@ export const getTopSuggestions = (querySuggestions, currentValue = '', showDisti
 export function isValidDateRangeQueryFormat(queryFormat) {
 	return Object.keys(dateFormats).includes(queryFormat);
 }
+
+export const suggestionTypes = {
+	Popular: 'popular',
+	Index: 'index',
+	Recent: 'recent',
+	Promoted: 'promoted',
+};


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description** The PR adds a `suggestionTypes` constant, which previously resided in the depending repos(reactivesearch-web & vue) at 2 places.

**Related PR** https://github.com/appbaseio/reactivesearch/pull/1842