### PR TITLE
feat: added utils supporting date-type support for range components

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -712,3 +712,51 @@ export const suggestionTypes = {
 	Recent: 'recent',
 	Promoted: 'promoted',
 };
+
+// this map helps to get the interval divider
+// for histogram, since the calendarinterval prop leaves
+export const queryFormatMillisecondsMap = {
+	// the below are arranged in asscending order
+	// please maintain the order if adding/ removing property(s)
+	minute: 60000,
+	hour: 3600000,
+	day: 86400000,
+	week: 604800000,
+	month: 2629746000,
+	quarter: 7889238000,
+	year: 31556952000,
+};
+
+// this function checks for subsequent calendarIntervals that would
+// yield intervals well within a max cap of 100
+// since displaying more than 100 bars on histogram isn't diserable
+export const getCalendarIntervalErrorMessage = (totalRange, calendarInterval = 'minute') => {
+	const queryFormatMillisecondsMapKeys = Object.keys(queryFormatMillisecondsMap);
+	const indexOfCurrentCalendarInterval = queryFormatMillisecondsMapKeys.indexOf(calendarInterval);
+	if (indexOfCurrentCalendarInterval === -1) {
+		console.error('Invalid calendarInterval Passed');
+	}
+
+	if (calendarInterval === 'year') {
+		return 'Try using a shorter range of values.';
+	}
+
+	for (
+		let index = indexOfCurrentCalendarInterval + 1;
+		index < queryFormatMillisecondsMapKeys.length;
+		index += 1
+	) {
+		if (totalRange / Object.values(queryFormatMillisecondsMap)[index] <= 100) {
+			const calendarIntervalKey = queryFormatMillisecondsMapKeys[index];
+			return {
+				errorMessage: `Please pass calendarInterval prop with value greater than or equal to a \`${calendarIntervalKey}\` for a meaningful resolution of histogram.`,
+				calculatedCalendarInterval: calendarIntervalKey,
+			};
+		}
+	}
+
+	return {
+		errorMessage: 'Try using a shorter range of values.',
+		calculatedCalendarInterval: 'year',
+	}; // we return the highest possible interval to shorten then interval value
+};

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -234,7 +234,7 @@ export const extractPropsFromState = (store, component, customOptions) => {
 			|| componentProps.componentType === componentTypes.rangeSlider
 		) {
 			calendarInterval = Object.keys(dateFormats).includes(queryFormat)
-				? componentProps.calendarInterval || 'month'
+				? componentProps.calendarInterval
 				: undefined;
 
 			// Set value


### PR DESCRIPTION
**PR Type** 🏗️ `Enhancement`

**Description** Adds util support for calendarInterval calculation in reactivecore. In future, it could be used by other libs such as rs-vue.

**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/1858