### PR TITLE
feat: support query generation for RL in case of sortOptions

### DIFF
--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -134,7 +134,7 @@ export const getRSQuery = (componentId, props, execute = true) => {
 					applyStopwords: props.applyStopwords,
 					customStopwords: props.customStopwords,
 					enablePredictiveSuggestions: props.enablePredictiveSuggestions,
-				}
+				  }
 				: {}),
 			calendarInterval: props.calendarInterval,
 		};
@@ -371,6 +371,14 @@ export const extractPropsFromState = (store, component, customOptions) => {
 	if (componentProps.componentType === componentTypes.reactiveList) {
 		// We set selected page as the value in the redux store for RL.
 		// It's complex to change this logic in the component so changed it here.
+		if (value instanceof Object) {
+			// since sortOption property is added regarding issue #261
+			// we now support object structure in redux for reactivelist url params
+			if (value.page > 0) {
+				value = value.page;
+			}
+		}
+
 		if (value > 0) {
 			from = (value - 1) * (componentProps.size || 10);
 		}
@@ -450,7 +458,7 @@ export const getDependentQueries = (store, componentID, orderOfQueries = []) => 
 								...(calcValues.category
 									? { categoryValue: calcValues.category }
 									: {}),
-							}
+							  }
 							: {}),
 					}),
 					execute,


### PR DESCRIPTION
**PR Type** 🏗️ `Enhancement`

**Description** supports correct query generation for ReactiveList when dealing with `sortOption` key in url-params.

[📔 Notion](https://www.notion.so/appbase/2a5bc1196ce6450793bd34f57ff6716b#625fdb9996d44a1caad3997ad345a524)

**Related PR(s)**
- https://github.com/appbaseio/reactivesearch/pull/1863
