### PR TITLE
fix: handle when dataField is an array for aggregations

### DIFF
--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -522,16 +522,34 @@ export const getAggsQuery = (value, query, props) => {
 		dataField, size, sortBy, showMissing, missingLabel,
 	} = props;
 	clonedQuery.size = 0;
-	clonedQuery.aggs = {
-		[dataField]: {
-			terms: {
-				field: dataField,
-				size,
-				order: getAggsOrder(sortBy || 'count'),
-				...(showMissing ? { missing: missingLabel } : {}),
+	if (typeof dataField === 'string') {
+		clonedQuery.aggs = {
+			[dataField]: {
+				terms: {
+					field: dataField,
+					size,
+					order: getAggsOrder(sortBy || 'count'),
+					...(showMissing ? { missing: missingLabel } : {}),
+				},
 			},
-		},
-	};
+		};
+	} else {
+		let aggs;
+		[...dataField].reverse().forEach((dataFieldItem) => {
+			aggs = {
+				[dataFieldItem]: {
+					terms: {
+						field: dataFieldItem,
+						size,
+						order: getAggsOrder(sortBy || 'count'),
+						...(showMissing ? { missing: missingLabel } : {}),
+					},
+					aggs,
+				},
+			};
+		});
+		clonedQuery.aggs = aggs;
+	}
 
 	if (props.nestedField) {
 		clonedQuery.aggs = {


### PR DESCRIPTION
With the addition of the `TreeList` component the `dataField` can now be a string or an array of strings. The helper method for `getAggsQuery` does not handle the case where `dataField` is an array however resulting in queries that do not work. (See https://github.com/appbaseio/reactivesearch/issues/2059)

I have another PR for the reactivesearch repo for further tweaks to handle the dataField being an array.