### PR TITLE
fix: append categoryValue in results query for CategorySearch component

### DIFF
--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -473,19 +473,28 @@ export const getDependentQueries = (store, componentID, orderOfQueries = []) => 
 				const dependentQuery = getRSQuery(
 					component,
 					extractPropsFromState(store, component, {
-						...(componentProps
-						&& componentProps.componentType === componentTypes.searchBox
-							? {
-								...(execute === false ? { type: queryTypes.search } : {}),
-								...(calcValues.category
-									? { categoryValue: calcValues.category }
-									: {}),
-								...(calcValues.value ? { value: calcValues.value } : {}),
-							  }
-							: {}),
+						...(componentProps && {
+							...(componentProps.componentType === componentTypes.searchBox
+								? {
+									...(execute === false ? { type: queryTypes.search } : {}),
+									...(calcValues.category
+										? { categoryValue: calcValues.category }
+										: { categoryValue: undefined }),
+									...(calcValues.value ? { value: calcValues.value } : {}),
+								  }
+								: {}),
+							...(componentProps.componentType === componentTypes.categorySearch
+								? {
+									...(calcValues.category
+										? { categoryValue: calcValues.category }
+										: { categoryValue: undefined }),
+								  }
+								: {}),
+						}),
 					}),
 					execute,
 				);
+
 				if (dependentQuery) {
 					finalQuery[component] = dependentQuery;
 				}


### PR DESCRIPTION
**PR Type** `fix`

**Description** The PR fixes a bug with the `<CategorySearch />` component wherein the results were not filtered based on the selected category.

https://www.loom.com/share/b7ff306a35ab4b0ca1d995c4ad53e6ac
